### PR TITLE
add paging to custom feature plots and allow smallMultipleUmaps to return list of figures

### DIFF
--- a/scripts/dimPlots.R
+++ b/scripts/dimPlots.R
@@ -21,7 +21,8 @@ DimPlotCustom <- function(
   groupByTitles = groupBy,
   minimalTheme = TRUE,
   nLegendCols = 5,
-  nCols = NULL
+  nCols = NULL,
+  ...
 ) {
   if (!(is.vector(groupBy) && is.atomic(groupBy))) {
     groupBy = c(groupBy)
@@ -36,7 +37,7 @@ DimPlotCustom <- function(
   names(groupByTitles) <- groupBy
   
   listP <- lapply(groupBy, function(x) {
-    p <- DimPlot(seu, reduction = reduction, group.by = x) +
+    p <- DimPlot(seu, reduction = reduction, group.by = x, ...) +
       labs(title = groupByTitles[x]) +
       minimalDimPlotTheme +
       guides(color = guide_legend(ncol = nLegendCols))
@@ -57,7 +58,8 @@ smallMultipleUmaps <- function(
   height = 6,
   width = 10,
   ncol = 8,
-  titleWrapNChars = 20
+  titleWrapNChars = 20,
+  return_figures = FALSE
 ) {
   
   colOfInterest <- FetchData(seu, parameter)
@@ -85,13 +87,18 @@ smallMultipleUmaps <- function(
     return(p)
   })
   
-  savePlot(
-    smallUmaps,
-    fn = filename,
-    customSavePlot = patchwork::wrap_plots(smallUmaps, ncol = ncol),
-    devices = devices,
-    gheight = height,
-    gwidth = width)
+  if (!return_figures) {
+    savePlot(
+      smallUmaps,
+      fn = filename,
+      customSavePlot = patchwork::wrap_plots(smallUmaps, ncol = ncol),
+      devices = devices,
+      gheight = height,
+      gwidth = width)
+  } else {
+    message("Returning list of plots.")
+    return(smallUmaps, ncol = ncol)
+  }
 }
 
 


### PR DESCRIPTION
This PR:

1. adds dimPlots::FeaturePlotCustomPaged, a wrapper around dimplots::FeaturePlotCustom that returns a list of feature plots, one element corresponding to each page

2. add `return_figures` parameter to dimPlots::smallMultipleUmaps() that returns the list of UMAP plots for additional processing